### PR TITLE
Add local bootstrap path

### DIFF
--- a/.env.demo.example
+++ b/.env.demo.example
@@ -1,0 +1,13 @@
+# FlowState NPR demo environment.
+# Copy to .env.demo or export these values in your shell before running the demo.
+
+# ANTHROPIC_API_KEY=sk-ant-...
+
+QDRANT_URL=http://localhost:6333
+QDRANT_COLLECTION=flowstate-recall
+OLLAMA_HOST=http://localhost:11434
+EMBEDDING_MODEL=nomic-embed-text
+
+FLOWSTATE_HOST=127.0.0.1
+PORT=8080
+VITE_API_BASE_URL=http://127.0.0.1:8080

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 .flowstate/autoresearch/
 .env
 .env.*
+!.env.demo.example
 
 # Build artifacts
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run test test-e2e test-external test-recall bdd bdd-smoke bdd-wip fmt lint check check-docblocks check-untested-packages check-note-comments check-keyword-adr check-gating-drift clean help ai-commit check-ai-attribution list-ai-commits coverage-check install-coverage-tools install-hooks debug-session debug-latest debug-errors session-overview log-analysis parse-recording session-history session-history-detail session-ids qdrant-up qdrant-down qdrant-logs qdrant-status
+.PHONY: all build run test test-e2e test-external test-recall bdd bdd-smoke bdd-wip fmt lint check check-docblocks check-untested-packages check-note-comments check-keyword-adr check-gating-drift clean help ai-commit check-ai-attribution list-ai-commits coverage-check install-coverage-tools install-hooks debug-session debug-latest debug-errors session-overview log-analysis parse-recording session-history session-history-detail session-ids qdrant-up qdrant-down qdrant-logs qdrant-status demo-bootstrap demo-qdrant-up demo-check demo-run
 
 # Binary name
 BINARY_NAME=flowstate
@@ -357,6 +357,25 @@ qdrant-status: ## Show Qdrant health and list collections
 	@echo "Collections:"
 	@curl -fsS http://127.0.0.1:6333/collections | jq -r '.result.collections[].name' 2>/dev/null \
 		|| echo "(curl/jq failed — is Qdrant up?)"
+
+#
+# Demo Install (FS NPR onboarding PoC)
+#
+
+demo-bootstrap: ## Bootstrap the first-time local demo path
+	bash scripts/bootstrap-demo.sh
+
+demo-qdrant-up: qdrant-up ## Start Qdrant for the demo
+
+demo-check: ## Check demo prerequisites without changing config or starting services
+	bash scripts/bootstrap-demo.sh --check-only
+
+demo-run: build ## Run the FlowState service for the demo
+	@if [ -f .env.demo ]; then \
+		set -a; . ./.env.demo; set +a; \
+	fi; \
+	echo "Starting FlowState demo service on $${FLOWSTATE_HOST:-127.0.0.1}:$${PORT:-8080}..."; \
+	./build/flowstate serve --host "$${FLOWSTATE_HOST:-127.0.0.1}" --port "$${PORT:-8080}"
 
 #
 # Web Frontend (Vue 3 + TypeScript)

--- a/docs/install/demo-quickstart.md
+++ b/docs/install/demo-quickstart.md
@@ -1,0 +1,254 @@
+# FlowState NPR Demo Quickstart
+
+## Who this is for
+
+This guide is for people setting up FlowState locally to evaluate the FS NPR onboarding proof of concept. It is a fallback path for local demos while hosted deployment decisions are still being made.
+
+NPR here means Neuropsychographic Registry: the structured profile object produced from the onboarding conversation.
+
+## What this installs
+
+The demo bootstrap prepares a local FlowState service runtime for the NPR onboarding swarm. It:
+
+- Builds the FlowState binary from this checkout when needed.
+- Creates `~/.config/flowstate/config.yaml` only when it is missing.
+- Starts Qdrant with the repo's existing `docker-compose.dev.yml`.
+- Pulls the `nomic-embed-text` embedding model with Ollama.
+- Materialises FlowState memory tools with `flowstate memory-tools install`.
+- Checks swarm discovery and agent inventory with the commands available in the installed FlowState build.
+
+It does not overwrite existing FlowState config, delete sessions, or install host tools such as Docker, Ollama, Go, Node.js, or Python.
+
+## Prerequisites
+
+- WSL2 or Linux.
+- Docker with the Compose v2 plugin.
+- Ollama running locally.
+- Go and Make, unless a `flowstate` binary is already on `PATH`.
+- Node.js and npm for the web UI.
+- Python 3 with either `venv` support or `pipx` for LlamaIndex and Qdrant vault tooling.
+- An Anthropic API key for the main orchestration provider.
+
+On Ubuntu or Debian, the common system packages are:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y docker.io docker-compose-plugin golang-go make nodejs npm python3 python3-venv pipx curl
+```
+
+Install Ollama from <https://ollama.com/download/linux>, then start it before bootstrapping.
+
+## Quickstart
+
+1. Clone the repo if you do not already have it:
+
+   ```bash
+   git clone https://github.com/baphled/flowstate.git
+   cd flowstate
+   ```
+
+2. Create a local demo environment file:
+
+   ```bash
+   cp .env.demo.example .env.demo
+   nano .env.demo
+   ```
+
+   Add your Anthropic API key in `.env.demo`, or export it in your shell:
+
+   ```bash
+   export ANTHROPIC_API_KEY="sk-ant-..."
+   ```
+
+3. Bootstrap the local demo stack:
+
+   ```bash
+   make demo-bootstrap
+   ```
+
+   This starts Qdrant, pulls the embedding model, installs memory tools, and checks that the NPR swarm is discoverable.
+
+4. Start the FlowState service:
+
+   ```bash
+   make demo-run
+   ```
+
+   The service defaults to `http://127.0.0.1:8080`.
+
+5. In another terminal, start the web UI if browser access is needed:
+
+   ```bash
+   make web-install
+   make web-dev
+   ```
+
+   The web UI defaults to the Vite URL shown by `make web-dev`.
+
+6. Start the onboarding flow from the same FlowState chat/session context:
+
+   ```text
+   @npr-onboarding Start a new NPR onboarding for userId=example-user
+   ```
+
+## Which local profile is used
+
+The normal demo commands use the machine's regular FlowState profile:
+
+```text
+~/.config/flowstate/config.yaml
+~/.local/share/flowstate/sessions/
+~/.local/share/flowstate/memory-tools/
+~/.local/share/qdrant/
+```
+
+If FlowState has already been used on the machine, existing sessions may appear in the UI. That is expected. The bootstrap script leaves an existing `~/.config/flowstate/config.yaml` untouched and reuses the existing sessions directory.
+
+To run the demo against an isolated temporary profile, export temporary XDG directories before both bootstrap and service startup:
+
+```bash
+export FLOWSTATE_DEMO_TEST_HOME="$(mktemp -d)"
+export XDG_CONFIG_HOME="$FLOWSTATE_DEMO_TEST_HOME/config"
+export XDG_DATA_HOME="$FLOWSTATE_DEMO_TEST_HOME/data"
+export ANTHROPIC_API_KEY="sk-ant-..."
+make demo-bootstrap
+make demo-run
+```
+
+The browser UI talks to whichever FlowState service is running on `127.0.0.1:8080`, so it will show the sessions from that service's active profile.
+
+To return to the normal profile, open a new terminal or run:
+
+```bash
+unset FLOWSTATE_DEMO_TEST_HOME XDG_CONFIG_HOME XDG_DATA_HOME
+```
+
+To remove only the temporary profile:
+
+```bash
+rm -rf "$FLOWSTATE_DEMO_TEST_HOME"
+```
+
+Do not delete `~/.local/share/qdrant/` unless you explicitly intend to discard local vector data. Do not use `docker compose down -v` for this demo stack.
+
+## What Docker is used for
+
+Docker is only used for Qdrant in this demo path. The bootstrap script starts:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d qdrant
+```
+
+The compose file binds Qdrant to `127.0.0.1:6333` and persists data under the host Qdrant directory.
+
+## What remains native
+
+FlowState itself runs natively on the host or WSL environment. Ollama runs natively. The `nomic-embed-text` model is pulled into Ollama. Python tooling for LlamaIndex and Qdrant vault workflows also remains native rather than running inside the Qdrant container.
+
+## Environment variables
+
+Use `.env.demo.example` as the starting point:
+
+```bash
+cp .env.demo.example .env.demo
+```
+
+Required for orchestration:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Useful demo defaults:
+
+```bash
+export QDRANT_URL="http://localhost:6333"
+export QDRANT_COLLECTION="flowstate-recall"
+export OLLAMA_HOST="http://localhost:11434"
+export EMBEDDING_MODEL="nomic-embed-text"
+```
+
+Do not commit provider API keys.
+
+## Running Qdrant
+
+Start Qdrant:
+
+```bash
+make demo-qdrant-up
+```
+
+Check Qdrant:
+
+```bash
+make qdrant-status
+```
+
+Stop Qdrant when the demo is finished:
+
+```bash
+make qdrant-down
+```
+
+Stopping Qdrant does not delete the host data directory.
+
+## Running FlowState service
+
+After `make demo-bootstrap`, start the local service:
+
+```bash
+make demo-run
+```
+
+This starts FlowState as a service endpoint rather than focusing on the TUI as the long-term interface.
+
+## Running the web UI
+
+Install dependencies once:
+
+```bash
+make web-install
+```
+
+Start the web app:
+
+```bash
+make web-dev
+```
+
+Keep `make demo-run` running in another terminal so the web UI can reach the FlowState API.
+
+## Troubleshooting
+
+- `docker compose` is missing: install Docker Compose v2, then verify with `docker compose version`.
+- `docker daemon` is missing: the Docker CLI is installed, but the Docker engine is not running.
+  - On Windows/WSL: open Docker Desktop, then enable the distro under Settings -> Resources -> WSL Integration.
+  - On native Linux: run `sudo systemctl start docker`, then check `docker info`.
+  - If `docker info` says permission denied: run `sudo usermod -aG docker "$USER"`, then log out/in or run `newgrp docker`.
+- Qdrant fails with `not a directory` or `Are you trying to mount a directory onto a file`: the host path Docker is trying to mount as a file is probably an empty directory from a failed first run. The bootstrap repairs an empty `~/.local/share/qdrant/config/config.yaml` directory automatically. If fixing manually, do not touch `storage` or `snapshots`; only replace that `config.yaml` directory with a file:
+
+  ```bash
+  rmdir ~/.local/share/qdrant/config/config.yaml
+  mkdir -p ~/.local/share/qdrant/config
+  printf '# FlowState demo Qdrant config.\n' > ~/.local/share/qdrant/config/config.yaml
+  ```
+
+- Qdrant setup fails with `Permission denied` under `~/.local/share/qdrant`: Docker probably created the directory with the wrong owner during a failed first run. Repair ownership, then rerun the bootstrap:
+
+  ```bash
+  sudo chown -R "$(id -u):$(id -g)" ~/.local/share/qdrant
+  make demo-bootstrap
+  ```
+
+- `ollama pull nomic-embed-text` fails: start Ollama with `ollama serve` or the desktop app, then rerun `make demo-bootstrap`.
+- Anthropic authentication fails: set `ANTHROPIC_API_KEY` or run the relevant `flowstate auth` command for the installed build.
+- Memory commands are missing: rerun `flowstate memory-tools install`.
+- Agent inventory differs by build: current builds expose `flowstate agent list`; some scripts or notes may refer to `flowstate agents list`.
+
+## Known limitations
+
+- This path is WSL/Linux first.
+- It does not install Docker, Ollama, Go, Node, or Python for you.
+- It does not overwrite an existing `~/.config/flowstate/config.yaml`.
+- It assumes Anthropic is the primary orchestration provider for the PoC.
+- It starts Qdrant locally, but it does not import or reindex a vault by itself.

--- a/features/install/demo_quickstart.feature
+++ b/features/install/demo_quickstart.feature
@@ -1,0 +1,43 @@
+@demo-install
+Feature: Demo quickstart installation
+  As a non-specialist NPR demo user
+  I want one documented local bootstrap path
+  So that I can run FlowState with memory and recall enabled
+
+  Scenario: Demo quickstart assets are available
+    Given the FlowState repository root is available
+    Then the demo quickstart document should mention:
+      | text                     |
+      | Who this is for          |
+      | What this installs       |
+      | Prerequisites            |
+      | Quickstart               |
+      | What Docker is used for  |
+      | What remains native      |
+      | Environment variables    |
+      | Running Qdrant           |
+      | Running FlowState service |
+      | Running the web UI       |
+      | Troubleshooting          |
+      | Known limitations        |
+    And the demo environment example should mention:
+      | text              |
+      | ANTHROPIC_API_KEY |
+      | QDRANT_URL        |
+      | QDRANT_COLLECTION |
+      | OLLAMA_HOST       |
+    And the demo bootstrap script should be executable
+    And the demo bootstrap script should mention:
+      | text                                           |
+      | docker compose -f docker-compose.dev.yml up -d qdrant |
+      | ollama pull nomic-embed-text                  |
+      | flowstate memory-tools install                |
+      | flowstate auth status                         |
+      | flowstate swarm list                          |
+      | flowstate agents list                         |
+    And the demo Makefile shortcuts should be available:
+      | target         |
+      | demo-bootstrap |
+      | demo-qdrant-up |
+      | demo-check     |
+      | demo-run       |

--- a/features/support/demo_install_steps.go
+++ b/features/support/demo_install_steps.go
@@ -1,0 +1,134 @@
+//go:build e2e
+
+package support
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+type demoInstallSteps struct {
+	repoRoot string
+}
+
+func registerDemoInstallSteps(ctx *godog.ScenarioContext) {
+	steps := &demoInstallSteps{}
+	ctx.Step(`^the FlowState repository root is available$`, steps.theFlowStateRepositoryRootIsAvailable)
+	ctx.Step(`^the demo quickstart document should mention:$`, steps.theDemoQuickstartDocumentShouldMention)
+	ctx.Step(`^the demo environment example should mention:$`, steps.theDemoEnvironmentExampleShouldMention)
+	ctx.Step(`^the demo bootstrap script should be executable$`, steps.theDemoBootstrapScriptShouldBeExecutable)
+	ctx.Step(`^the demo bootstrap script should mention:$`, steps.theDemoBootstrapScriptShouldMention)
+	ctx.Step(`^the demo Makefile shortcuts should be available:$`, steps.theDemoMakefileShortcutsShouldBeAvailable)
+}
+
+func (s *demoInstallSteps) theFlowStateRepositoryRootIsAvailable() error {
+	root, err := findRepositoryRoot()
+	if err != nil {
+		return err
+	}
+	s.repoRoot = root
+	return nil
+}
+
+func (s *demoInstallSteps) theDemoQuickstartDocumentShouldMention(table *godog.Table) error {
+	return s.fileShouldMention("docs/install/demo-quickstart.md", table)
+}
+
+func (s *demoInstallSteps) theDemoEnvironmentExampleShouldMention(table *godog.Table) error {
+	return s.fileShouldMention(".env.demo.example", table)
+}
+
+func (s *demoInstallSteps) theDemoBootstrapScriptShouldBeExecutable() error {
+	path := filepath.Join(s.mustRepoRoot(), "scripts", "bootstrap-demo.sh")
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat demo bootstrap script: %w", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		return fmt.Errorf("expected %s to be executable", path)
+	}
+	return nil
+}
+
+func (s *demoInstallSteps) theDemoBootstrapScriptShouldMention(table *godog.Table) error {
+	return s.fileShouldMention("scripts/bootstrap-demo.sh", table)
+}
+
+func (s *demoInstallSteps) theDemoMakefileShortcutsShouldBeAvailable(table *godog.Table) error {
+	content, err := s.readRepoFile("Makefile")
+	if err != nil {
+		return err
+	}
+	for _, target := range tableValues(table) {
+		needle := "\n" + target + ":"
+		if !strings.Contains("\n"+content, needle) {
+			return fmt.Errorf("expected Makefile target %q", target)
+		}
+	}
+	return nil
+}
+
+func (s *demoInstallSteps) fileShouldMention(path string, table *godog.Table) error {
+	content, err := s.readRepoFile(path)
+	if err != nil {
+		return err
+	}
+	for _, text := range tableValues(table) {
+		if !strings.Contains(content, text) {
+			return fmt.Errorf("expected %s to contain %q", path, text)
+		}
+	}
+	return nil
+}
+
+func (s *demoInstallSteps) readRepoFile(path string) (string, error) {
+	content, err := os.ReadFile(filepath.Join(s.mustRepoRoot(), filepath.FromSlash(path)))
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	return string(content), nil
+}
+
+func (s *demoInstallSteps) mustRepoRoot() string {
+	if s.repoRoot != "" {
+		return s.repoRoot
+	}
+	root, err := findRepositoryRoot()
+	if err != nil {
+		panic(err)
+	}
+	s.repoRoot = root
+	return root
+}
+
+func tableValues(table *godog.Table) []string {
+	values := make([]string, 0, len(table.Rows))
+	for i, row := range table.Rows {
+		if i == 0 || len(row.Cells) == 0 {
+			continue
+		}
+		values = append(values, row.Cells[0].Value)
+	}
+	return values
+}
+
+func findRepositoryRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find repository root from %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/features/support/godog_test.go
+++ b/features/support/godog_test.go
@@ -95,4 +95,5 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	RegisterAdultingMemorySteps(ctx)
 	RegisterAdultingDeadlineSteps(ctx)
 	RegisterVaultIndexSyncSteps(ctx)
+	registerDemoInstallSteps(ctx)
 }

--- a/scripts/bootstrap-demo.sh
+++ b/scripts/bootstrap-demo.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_BASE="${XDG_CONFIG_HOME:-$HOME/.config}"
+DATA_BASE="${XDG_DATA_HOME:-$HOME/.local/share}"
+CONFIG_DIR="$CONFIG_BASE/flowstate"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+DATA_DIR="$DATA_BASE/flowstate"
+QDRANT_HOME="$HOME/.local/share/qdrant"
+QDRANT_CONFIG_FILE="$QDRANT_HOME/config/config.yaml"
+QDRANT_STORAGE_DIR="$QDRANT_HOME/storage"
+QDRANT_SNAPSHOTS_DIR="$QDRANT_HOME/snapshots"
+QDRANT_URL="${QDRANT_URL:-http://localhost:6333}"
+QDRANT_COLLECTION="${QDRANT_COLLECTION:-flowstate-recall}"
+OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
+EMBEDDING_MODEL="${EMBEDDING_MODEL:-nomic-embed-text}"
+FLOWSTATE_CMD="${FLOWSTATE_BIN:-}"
+NEEDS_BUILD=0
+CHECK_ONLY=0
+SKIP_OLLAMA_PULL=0
+WARNINGS=()
+MISSING=()
+
+usage() {
+	cat <<'USAGE'
+Usage: scripts/bootstrap-demo.sh [--check-only] [--skip-ollama-pull]
+
+Bootstraps the local FS NPR FlowState demo path for WSL/Linux:
+  - checks required host tools
+  - creates ~/.config/flowstate/config.yaml only when missing
+  - starts Qdrant with docker compose -f docker-compose.dev.yml up -d qdrant
+  - runs ollama pull nomic-embed-text
+  - runs flowstate memory-tools install
+  - runs flowstate auth status, flowstate swarm list, and agent inventory
+
+ANTHROPIC_API_KEY is required for the main orchestration provider.
+USAGE
+}
+
+info() {
+	printf '\n==> %s\n' "$*"
+}
+
+note() {
+	printf '  %s\n' "$*"
+}
+
+warn() {
+	WARNINGS+=("$*")
+	printf '  Warning: %s\n' "$*"
+}
+
+missing() {
+	MISSING+=("$1"$'\n'"$2")
+}
+
+has() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--check-only)
+				CHECK_ONLY=1
+				;;
+			--skip-ollama-pull)
+				SKIP_OLLAMA_PULL=1
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			*)
+				printf 'Unknown option: %s\n\n' "$1" >&2
+				usage >&2
+				exit 2
+				;;
+		esac
+		shift
+	done
+}
+
+check_docker() {
+	if ! has docker; then
+		missing "docker" "Install Docker Desktop with WSL integration, or install Docker Engine plus the Compose v2 plugin. Ubuntu/Debian: sudo apt-get install -y docker.io docker-compose-plugin"
+		return
+	fi
+	if ! docker compose version >/dev/null 2>&1; then
+		missing "docker compose" "Install the Docker Compose v2 plugin, then verify with: docker compose version"
+		return
+	fi
+	local docker_info
+	docker_info="$(docker info 2>&1 >/dev/null || true)"
+	if [[ -n "$docker_info" ]]; then
+		if [[ "$docker_info" == *"permission denied"* || "$docker_info" == *"Got permission denied"* ]]; then
+			missing "docker permissions" "Your user cannot access the Docker daemon. On Linux run: sudo usermod -aG docker \"$USER\", then log out/in or run: newgrp docker"
+			return
+		fi
+		missing "docker daemon" "Start Docker Desktop with WSL integration enabled, or start Docker on Linux with: sudo systemctl start docker"
+	fi
+}
+
+check_ollama() {
+	if ! has ollama; then
+		missing "ollama" "Install Ollama from https://ollama.com/download/linux, start it, then rerun this script."
+	fi
+}
+
+check_curl() {
+	if ! has curl; then
+		missing "curl" "Install curl. Ubuntu/Debian: sudo apt-get install -y curl"
+	fi
+}
+
+check_python_tooling() {
+	if ! has python3; then
+		missing "python3" "Install Python 3. Ubuntu/Debian: sudo apt-get install -y python3 python3-venv pipx"
+		return
+	fi
+	if python3 -m venv --help >/dev/null 2>&1 || has pipx; then
+		return
+	fi
+	missing "python3 venv or pipx" "Install python3-venv or pipx for the LlamaIndex/Qdrant vault tooling."
+}
+
+check_node() {
+	if ! has npm; then
+		warn "npm was not found. Install Node.js and npm before running make web-install or make web-dev."
+	fi
+}
+
+check_anthropic_key() {
+	if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+		warn "ANTHROPIC_API_KEY is not set. Set it before the orchestration demo: export ANTHROPIC_API_KEY='sk-ant-...'"
+	fi
+}
+
+check_flowstate() {
+	if [[ -n "$FLOWSTATE_CMD" && -x "$FLOWSTATE_CMD" ]]; then
+		return
+	fi
+	if has flowstate; then
+		FLOWSTATE_CMD="$(command -v flowstate)"
+		return
+	fi
+	if [[ -x "$REPO_ROOT/build/flowstate" ]]; then
+		FLOWSTATE_CMD="$REPO_ROOT/build/flowstate"
+		return
+	fi
+	if has make && has go; then
+		FLOWSTATE_CMD="$REPO_ROOT/build/flowstate"
+		NEEDS_BUILD=1
+		return
+	fi
+	missing "flowstate binary" "Install FlowState on PATH or install Go and Make so this script can run make build."
+}
+
+print_missing_and_exit() {
+	if [[ ${#MISSING[@]} -eq 0 ]]; then
+		return
+	fi
+	printf '\nBootstrap cannot continue yet. Missing prerequisites:\n'
+	for item in "${MISSING[@]}"; do
+		printf '\n%s\n' "$item"
+	done
+	printf '\nAfter installing the missing prerequisites, rerun: make demo-bootstrap\n'
+	exit 1
+}
+
+build_flowstate_if_needed() {
+	if [[ "$NEEDS_BUILD" -eq 0 ]]; then
+		return
+	fi
+	info "Building FlowState"
+	(cd "$REPO_ROOT" && make build)
+}
+
+write_config_if_missing() {
+	if [[ -f "$CONFIG_FILE" ]]; then
+		info "FlowState config already exists"
+		note "Leaving $CONFIG_FILE untouched."
+		return
+	fi
+	info "Creating demo FlowState config"
+	mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+	cat > "$CONFIG_FILE" <<CONFIG
+providers:
+  default: anthropic
+  anthropic:
+    model: claude-sonnet-4-20250514
+  ollama:
+    host: "$OLLAMA_HOST"
+    model: llama3.2
+qdrant:
+  url: "$QDRANT_URL"
+  collection: "$QDRANT_COLLECTION"
+  api_key: ""
+embedding_model: "$EMBEDDING_MODEL"
+agent_dir: "$CONFIG_DIR/agents"
+skill_dir: "$CONFIG_DIR/skills"
+data_dir: "$DATA_DIR"
+default_agent: default-assistant
+log_level: info
+CONFIG
+	note "Wrote $CONFIG_FILE"
+}
+
+qdrant_permission_error() {
+	local path="$1"
+	printf '\nQdrant host path is not writable by %s:\n  %s\n' "${USER:-the current user}" "$path" >&2
+	printf '\nThis often happens after Docker creates the path during a failed first run.\n' >&2
+	printf 'Repair ownership, then rerun make demo-bootstrap:\n\n' >&2
+	printf '  sudo chown -R "$(id -u):$(id -g)" "%s"\n\n' "$QDRANT_HOME" >&2
+	printf 'The bootstrap will then replace an empty config.yaml directory with the config file Qdrant expects.\n' >&2
+	exit 1
+}
+
+ensure_qdrant_host_paths() {
+	info "Preparing Qdrant host paths"
+	mkdir -p "$(dirname "$QDRANT_CONFIG_FILE")" "$QDRANT_STORAGE_DIR" "$QDRANT_SNAPSHOTS_DIR"
+	if [[ ! -w "$(dirname "$QDRANT_CONFIG_FILE")" ]]; then
+		qdrant_permission_error "$(dirname "$QDRANT_CONFIG_FILE")"
+	fi
+	if [[ -d "$QDRANT_CONFIG_FILE" ]]; then
+		if [[ -n "$(find "$QDRANT_CONFIG_FILE" -mindepth 1 -print -quit)" ]]; then
+			printf '\nQdrant config path is a directory and is not empty:\n  %s\n' "$QDRANT_CONFIG_FILE" >&2
+			printf 'Move it aside or replace it with a file before rerunning make demo-bootstrap.\n' >&2
+			exit 1
+		fi
+		if ! rmdir "$QDRANT_CONFIG_FILE"; then
+			qdrant_permission_error "$QDRANT_CONFIG_FILE"
+		fi
+		note "Replaced empty directory at $QDRANT_CONFIG_FILE with a config file."
+	fi
+	if [[ ! -e "$QDRANT_CONFIG_FILE" ]]; then
+		printf '# FlowState demo Qdrant config.\n' > "$QDRANT_CONFIG_FILE"
+		note "Created $QDRANT_CONFIG_FILE"
+	fi
+	if [[ ! -f "$QDRANT_CONFIG_FILE" ]]; then
+		printf '\nQdrant config path must be a file for docker-compose.dev.yml:\n  %s\n' "$QDRANT_CONFIG_FILE" >&2
+		exit 1
+	fi
+}
+
+start_qdrant() {
+	info "Starting Qdrant"
+	note "Running: docker compose -f docker-compose.dev.yml up -d qdrant"
+	(cd "$REPO_ROOT" && docker compose -f docker-compose.dev.yml up -d qdrant)
+}
+
+pull_embedding_model() {
+	if [[ "$SKIP_OLLAMA_PULL" -eq 1 ]]; then
+		info "Skipping Ollama model pull"
+		note "Run later: ollama pull nomic-embed-text"
+		return
+	fi
+	info "Pulling Ollama embedding model"
+	note "Running: ollama pull nomic-embed-text"
+	if ! OLLAMA_HOST="$OLLAMA_HOST" ollama pull "$EMBEDDING_MODEL"; then
+		printf '\nOllama could not pull %s. Start Ollama, then rerun:\n  ollama pull nomic-embed-text\n' "$EMBEDDING_MODEL" >&2
+		exit 1
+	fi
+}
+
+run_flowstate_required() {
+	info "$1"
+	shift
+	note "Running: flowstate $*"
+	if ! "$FLOWSTATE_CMD" "$@"; then
+		printf '\nFlowState command failed: flowstate %s\n' "$*" >&2
+		exit 1
+	fi
+}
+
+run_flowstate_optional() {
+	info "$1"
+	shift
+	note "Running: flowstate $*"
+	if ! "$FLOWSTATE_CMD" "$@"; then
+		warn "flowstate $* did not complete. Review the output above and rerun it manually."
+	fi
+}
+
+subcommand_available() {
+	local parent="$1"
+	local child="$2"
+	local help
+	help="$("$FLOWSTATE_CMD" "$parent" --help 2>/dev/null || true)"
+	printf '%s\n' "$help" | grep -Eq "^[[:space:]]+$child[[:space:]]"
+}
+
+run_auth_status() {
+	info "Checking provider authentication"
+	note "Requested demo check: flowstate auth status"
+	if subcommand_available auth status; then
+		note "Running: flowstate auth status"
+		if ! "$FLOWSTATE_CMD" auth status; then
+			warn "flowstate auth status did not complete. Verify ANTHROPIC_API_KEY or provider auth manually."
+		fi
+		return
+	fi
+	warn "this build does not expose flowstate auth status. Run flowstate auth --help and verify ANTHROPIC_API_KEY before the demo."
+}
+
+run_agent_inventory() {
+	info "Checking agent inventory"
+	note "Current builds use: flowstate agent list"
+	note "Plural command requested for demo checks: flowstate agents list"
+	if subcommand_available agents list; then
+		note "Running: flowstate agents list"
+		if ! "$FLOWSTATE_CMD" agents list; then
+			warn "flowstate agents list did not complete."
+		fi
+		return
+	fi
+	if ! subcommand_available agent list; then
+		warn "neither flowstate agents list nor flowstate agent list is available in this build."
+		return
+	fi
+	note "Running: flowstate agent list"
+	if ! "$FLOWSTATE_CMD" agent list; then
+		warn "flowstate agent list did not complete."
+	fi
+}
+
+print_summary() {
+	printf '\n'
+	if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+		printf 'Bootstrap completed with warnings:\n'
+		for warning in "${WARNINGS[@]}"; do
+			printf '  - %s\n' "$warning"
+		done
+		printf '\n'
+	fi
+	printf 'Success: FlowState demo bootstrap completed.\n'
+	printf 'Next command: make demo-run\n'
+	printf 'Then open another terminal and run: make web-install && make web-dev\n'
+}
+
+main() {
+	parse_args "$@"
+	info "Checking FlowState demo prerequisites"
+	check_docker
+	check_ollama
+	check_curl
+	check_python_tooling
+	check_node
+	check_anthropic_key
+	check_flowstate
+	print_missing_and_exit
+	if [[ "$CHECK_ONLY" -eq 1 ]]; then
+		printf '\nDemo prerequisite check completed.\n'
+		exit 0
+	fi
+	build_flowstate_if_needed
+	write_config_if_missing
+	ensure_qdrant_host_paths
+	start_qdrant
+	pull_embedding_model
+	run_flowstate_required "Installing FlowState memory tools" memory-tools install
+	run_auth_status
+	run_flowstate_optional "Checking swarms" swarm list
+	run_agent_inventory
+	print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a small documentation-first bootstrap path for running the FS NPR onboarding demo locally.

This introduces:

- `docs/install/demo-quickstart.md` for new evaluator setup
- `.env.demo.example` for demo environment defaults
- `scripts/bootstrap-demo.sh` for idempotent local setup checks
- Make shortcuts for demo bootstrap, Qdrant startup, checks, and service run
- BDD coverage for the demo install assets

The bootstrap path starts Qdrant via the existing `docker-compose.dev.yml`, pulls the Ollama `nomic-embed-text` embedding model, installs FlowState memory tools, checks swarm/agent discovery, and avoids overwriting existing FlowState config.

## Notes

- Qdrant and memory are treated as required for the NPR demo path.
- Existing `~/.config/flowstate/config.yaml` is left untouched.
- Existing local sessions may appear in the web UI unless the user runs with temporary XDG config/data directories.
- The script includes clearer handling for common WSL/Linux Docker and Qdrant bind-mount setup failures.

## Validation

- `bash -n scripts/bootstrap-demo.sh`
- `GOCACHE=/tmp/flowstate-gocache GODOG_TAGS='@demo-install' go test -tags e2e ./features/support -run TestFeatures`
- `git diff --check`

## Not Run

- `shellcheck scripts/bootstrap-demo.sh` because `shellcheck` was not installed in the local environment.