### PR TITLE
Fix CSRF token binding and auth-aware chat bootstrap

### DIFF
--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -53,11 +53,11 @@ func DefaultCSRFConfig() CSRFConfig {
 //
 // Composition (plan §"CSRF" lines 287-296):
 //
-//   handler = RequireOrigin(originCfg,                                // PR1
-//             RequireSession(sessionMgr,                              // C6
-//             Protect(csrfCfg)(                                       // C5 layer 1
-//             RequireCSRFRecordBound(sessionMgr)(                     // C5 layer 2
-//             innerHandler))))
+//	handler = RequireOrigin(originCfg,                                // PR1
+//	          RequireSession(sessionMgr,                              // C6
+//	          Protect(csrfCfg)(                                       // C5 layer 1
+//	          RequireCSRFRecordBound(sessionMgr)(                     // C5 layer 2
+//	          innerHandler))))
 //
 // Order matters: Origin → Session → gorilla/csrf → Record-bound CSRF →
 // inner. gorilla/csrf BEFORE Record-bound because gorilla rejects forged
@@ -86,7 +86,7 @@ func Protect(cfg CSRFConfig) func(http.Handler) http.Handler {
 }
 
 // RequireCSRFRecordBound is the SECOND CSRF layer — runs after gorilla/csrf
-// has validated the signed cookie ↔ header pair. Compares the unmasked
+// has validated the signed cookie ↔ header pair. Compares the
 // X-CSRF-Token header against the current session's Record.CSRFToken.
 //
 // Pre-condition: RequireSession has run, so requestRecord(r) returns a

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -50,9 +50,11 @@ type LoginPrincipalView struct {
 //	shape. Detailed reason is logged via slog.Warn for the operator.
 //
 // Per the plan §"Login request / response" line 445: login POST does NOT
-// require an inbound X-CSRF-Token. SameSite=Lax + Origin allowlist close
-// the cross-origin attack vector at the perimeter (RequireOrigin runs
-// before HandleLogin in the route wiring).
+// require an inbound X-CSRF-Token when called directly. The production
+// LoginChain still runs gorilla/csrf around this handler; when present,
+// HandleLogin returns the masked token from that layer and stores the same
+// value on the session record so the next protected request can satisfy both
+// CSRF checks with one X-CSRF-Token header.
 func HandleLogin(source identity.Source, sessionMgr *SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -104,6 +106,15 @@ func HandleLogin(source identity.Source, sessionMgr *SessionManager) http.Handle
 			slog.Error("auth login: post-mint lookup failed",
 				"mode", source.Mode(),
 				"err", errString(err),
+			)
+			http.Error(w, "session_mint_failed", http.StatusInternalServerError)
+			return
+		}
+
+		if err := bindLoginCSRFToken(r, sessionMgr, rec); err != nil {
+			slog.Error("auth login: csrf bind failed",
+				"mode", source.Mode(),
+				"err", err.Error(),
 			)
 			http.Error(w, "session_mint_failed", http.StatusInternalServerError)
 			return
@@ -271,6 +282,15 @@ func errString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+func bindLoginCSRFToken(r *http.Request, sessionMgr *SessionManager, rec *store.Record) error {
+	token := csrf.Token(r)
+	if token == "" || token == rec.CSRFToken {
+		return nil
+	}
+	rec.CSRFToken = token
+	return sessionMgr.store.Put(r.Context(), rec)
 }
 
 // lookupForLogin is a thin wrapper around the SessionManager's store

--- a/internal/auth/login_test.go
+++ b/internal/auth/login_test.go
@@ -18,14 +18,14 @@ import (
 
 var _ = Describe("HandleLogin (B8 mode-fingerprint defence)", func() {
 	var (
-		mem  *store.MemoryStore
-		mgr  *auth.SessionManager
-		now  time.Time
+		mem *store.MemoryStore
+		mgr *auth.SessionManager
+		now time.Time
 	)
 
 	BeforeEach(func() {
 		mem = store.NewMemoryStore()
-		now = time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+		now = time.Date(2030, 5, 13, 12, 0, 0, 0, time.UTC)
 	})
 
 	newMgr := func(mode string) *auth.SessionManager {
@@ -70,6 +70,88 @@ var _ = Describe("HandleLogin (B8 mode-fingerprint defence)", func() {
 			Expect(resp.CSRFToken).NotTo(BeEmpty())
 			Expect(resp.Principal.ID).To(Equal("default"))
 			Expect(resp.Principal.Mode).To(Equal(identity.ModeSharedSecret))
+		})
+
+		It("returns a CSRF token that passes the protected unsafe-method gate", func() {
+			src := identity.NewSharedSecretSource("hunter2")
+			mgr = newMgr(identity.ModeSharedSecret)
+			originCfg := auth.OriginConfig{AllowedOrigins: []string{"localhost:*"}}
+			csrfCfg := auth.CSRFConfig{
+				AuthKey:        []byte("32-byte-test-key-padding-ok-yes!"),
+				CookieName:     "_csrf",
+				CookiePath:     "/api",
+				SecureCookies:  false,
+				TrustedOrigins: []string{"localhost:5173"},
+			}
+			csrfH := auth.LoginChain(originCfg, csrfCfg, auth.HandleCSRFPrefetch())
+
+			csrfReq := httptest.NewRequest(http.MethodGet, "/api/auth/csrf", nil)
+			csrfReq.Header.Set("Sec-Fetch-Site", "same-origin")
+			csrfRec := httptest.NewRecorder()
+			csrfH.ServeHTTP(csrfRec, csrfReq)
+			Expect(csrfRec.Code).To(Equal(http.StatusOK))
+
+			var preflight struct {
+				CSRFToken string `json:"csrf_token"`
+			}
+			Expect(json.NewDecoder(csrfRec.Body).Decode(&preflight)).To(Succeed())
+			Expect(preflight.CSRFToken).NotTo(BeEmpty())
+
+			var csrfCookie *http.Cookie
+			for _, c := range csrfRec.Result().Cookies() {
+				if c.Name == "_csrf" {
+					csrfCookie = c
+				}
+			}
+			Expect(csrfCookie).NotTo(BeNil())
+
+			loginH := auth.LoginChain(originCfg, csrfCfg, auth.HandleLogin(src, mgr))
+			loginReq := httptest.NewRequest(http.MethodPost, "/api/auth/login",
+				strings.NewReader(`{"secret":"hunter2"}`))
+			loginReq.Header.Set("Origin", "http://localhost:5173")
+			loginReq.Header.Set("Sec-Fetch-Site", "same-origin")
+			loginReq.Header.Set("Content-Type", "application/json")
+			loginReq.Header.Set("X-CSRF-Token", preflight.CSRFToken)
+			loginReq.AddCookie(csrfCookie)
+			loginRec := httptest.NewRecorder()
+			loginH.ServeHTTP(loginRec, loginReq)
+			Expect(loginRec.Code).To(Equal(http.StatusOK))
+
+			var loginResp auth.LoginResponse
+			Expect(json.NewDecoder(loginRec.Body).Decode(&loginResp)).To(Succeed())
+			Expect(loginResp.CSRFToken).NotTo(BeEmpty())
+
+			var sessionCookie *http.Cookie
+			for _, c := range loginRec.Result().Cookies() {
+				if c.Name == "flowstate_session" {
+					sessionCookie = c
+				}
+				if c.Name == "_csrf" {
+					csrfCookie = c
+				}
+			}
+			Expect(sessionCookie).NotTo(BeNil())
+			Expect(csrfCookie).NotTo(BeNil())
+
+			protectedH := auth.Protected(originCfg, mgr,
+				auth.AuthConfig{Enabled: true, Mode: identity.ModeSharedSecret},
+				csrfCfg,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}),
+			)
+			protectedReq := httptest.NewRequest(http.MethodPost, "/api/v1/sessions",
+				strings.NewReader(`{"agent_id":"planner"}`))
+			protectedReq.Header.Set("Origin", "http://localhost:5173")
+			protectedReq.Header.Set("Sec-Fetch-Site", "same-origin")
+			protectedReq.Header.Set("Content-Type", "application/json")
+			protectedReq.Header.Set("X-CSRF-Token", loginResp.CSRFToken)
+			protectedReq.AddCookie(csrfCookie)
+			protectedReq.AddCookie(sessionCookie)
+			protectedRec := httptest.NewRecorder()
+			protectedH.ServeHTTP(protectedRec, protectedReq)
+
+			Expect(protectedRec.Code).To(Equal(http.StatusNoContent), protectedRec.Body.String())
 		})
 
 		// Plan §"Test Strategy" line 624.

--- a/internal/auth/store/store.go
+++ b/internal/auth/store/store.go
@@ -53,10 +53,11 @@ var ErrNotImplemented = errors.New("auth/store: backend not implemented in v1; c
 //     Stamped at mint; checked at RequireSession (PR2/C4); mode-mismatch → 401.
 //   - PrincipalID — identity-source-provided principal id (e.g. username,
 //     deployment id).
-//   - CSRFToken   — unmasked plain-text token bound to this record. NOT the
-//     signed cookie value; the layered RequireCSRF middleware (PR2/C5)
-//     compares the X-CSRF-Token header against this field after gorilla/csrf
-//     has validated the signed cookie.
+//   - CSRFToken   — request token bound to this record. Browser login flows
+//     store the masked gorilla token returned in the login response; the
+//     layered RequireCSRF middleware (PR2/C5) compares the X-CSRF-Token
+//     header against this field after gorilla/csrf has validated the signed
+//     cookie.
 //   - CreatedAt   — mint timestamp.
 //   - ExpiresAt   — TTL boundary; Get returns ErrSessionNotFound past this
 //     instant. Cleanup sweeps records older than the supplied `before`.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -273,10 +274,10 @@ const engineShutdownTimeout = 30 * time.Second
 //   - PrincipalID:    env FLOWSTATE_AUTH_PRINCIPAL_ID → cfg.Auth.PrincipalID
 //   - DisplayName:    env FLOWSTATE_AUTH_DISPLAY_NAME → cfg.Auth.DisplayName
 //   - AllowedOrigins: env FLOWSTATE_AUTH_ALLOWED_ORIGINS (CSV) →
-//                     cfg.Auth.AllowedOrigins → ["localhost:*"]
+//     cfg.Auth.AllowedOrigins → ["localhost:*"]
 //   - SecureCookies:  env FLOWSTATE_AUTH_SECURE_COOKIES → cfg.Auth.SecureCookies
 //   - CSRFKey:        env FLOWSTATE_AUTH_CSRF_KEY → cfg.Auth.CSRFKey →
-//                     FAIL (no ephemeral fallback per PR5/C10)
+//     FAIL (no ephemeral fallback per PR5/C10)
 //
 // Expected:
 //   - apiServer is non-nil.
@@ -379,16 +380,7 @@ func buildAuthBundle(cfg *config.AppConfig) (api.AuthBundle, *store.MemoryStore,
 	csrfCfg := auth.DefaultCSRFConfig()
 	csrfCfg.AuthKey = csrfKey
 	csrfCfg.SecureCookies = secureCookies
-	// QA WARN-5 fix (May 2026): thread the resolved AllowedOrigins
-	// allowlist through gorilla/csrf's TrustedOrigins. Without this,
-	// every cross-origin POST was rejected at the CSRF gate regardless
-	// of the auth allowlist — gorilla/csrf has its OWN Origin check
-	// (exact-host match against TrustedOrigins) that runs in parallel
-	// to RequireOrigin. Sharing the slice keeps the two layers in
-	// lockstep so a cross-origin request the perimeter accepts isn't
-	// silently dropped by the CSRF middleware. See
-	// internal/auth/csrf.go:35 (CSRFConfig.TrustedOrigins doc).
-	csrfCfg.TrustedOrigins = allowed
+	csrfCfg.TrustedOrigins = csrfTrustedOriginsFor(allowed)
 
 	bundle := api.AuthBundle{
 		Origin:  auth.OriginConfig{AllowedOrigins: allowed},
@@ -401,6 +393,52 @@ func buildAuthBundle(cfg *config.AppConfig) (api.AuthBundle, *store.MemoryStore,
 		IdentitySource: source,
 	}
 	return bundle, memStore, nil
+}
+
+func csrfTrustedOriginsFor(allowed []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(allowed))
+	add := func(host string) {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			return
+		}
+		if _, ok := seen[host]; ok {
+			return
+		}
+		seen[host] = struct{}{}
+		out = append(out, host)
+	}
+	addLocalDevHosts := func(hostname string) {
+		for _, port := range []string{"4173", "5173", "5174", "5175"} {
+			add(hostname + ":" + port)
+		}
+	}
+	for _, item := range allowed {
+		value := strings.TrimSpace(item)
+		switch value {
+		case "localhost:*":
+			addLocalDevHosts("localhost")
+			addLocalDevHosts("127.0.0.1")
+			addLocalDevHosts("[::1]")
+			continue
+		case "127.0.0.1:*":
+			addLocalDevHosts("127.0.0.1")
+			continue
+		case "[::1]:*":
+			addLocalDevHosts("[::1]")
+			continue
+		}
+		if strings.Contains(value, "://") {
+			parsed, err := url.Parse(value)
+			if err == nil && parsed.Host != "" {
+				add(parsed.Host)
+				continue
+			}
+		}
+		add(value)
+	}
+	return out
 }
 
 // resolveAuthConfig returns the effective config.AuthConfig after
@@ -509,9 +547,9 @@ func multiUserPath() string {
 // worse than refusing to start.
 //
 // Resolution order (highest precedence first):
-//   1. FLOWSTATE_AUTH_CSRF_KEY env var
-//   2. cfgKey (cfg.Auth.CSRFKey)
-//   3. ERROR — operator must configure a key.
+//  1. FLOWSTATE_AUTH_CSRF_KEY env var
+//  2. cfgKey (cfg.Auth.CSRFKey)
+//  3. ERROR — operator must configure a key.
 //
 // Key padding/truncation: a configured key is materialised into a
 // 32-byte slice. Keys shorter than 32 bytes are zero-padded (gorilla/csrf

--- a/internal/cli/serve_auth_config_test.go
+++ b/internal/cli/serve_auth_config_test.go
@@ -235,9 +235,13 @@ func TestBuildAuthBundle_ThreadsTrustedOrigins(t *testing.T) {
 	t.Setenv("FLOWSTATE_AUTH_CSRF_KEY", "")
 	t.Setenv("FLOWSTATE_AUTH_ALLOWED_ORIGINS", "")
 
-	want := []string{
+	allowed := []string{
 		"https://flowstate.example.com",
 		"https://flowstate-staging.example.com",
+	}
+	wantTrusted := []string{
+		"flowstate.example.com",
+		"flowstate-staging.example.com",
 	}
 	cfg := &config.AppConfig{
 		Auth: config.AuthConfig{
@@ -247,7 +251,7 @@ func TestBuildAuthBundle_ThreadsTrustedOrigins(t *testing.T) {
 			PrincipalID:    "operator-id",
 			CSRFKey:        strings.Repeat("a", 32),
 			SecureCookies:  true,
-			AllowedOrigins: want,
+			AllowedOrigins: allowed,
 		},
 	}
 
@@ -256,22 +260,19 @@ func TestBuildAuthBundle_ThreadsTrustedOrigins(t *testing.T) {
 		t.Fatalf("buildAuthBundle: %v", err)
 	}
 
-	// The CSRF allowlist must match the Origin allowlist byte-for-byte.
-	if len(bundle.CSRF.TrustedOrigins) != len(want) {
+	if len(bundle.CSRF.TrustedOrigins) != len(wantTrusted) {
 		t.Fatalf("CSRF.TrustedOrigins length: got %d, want %d",
-			len(bundle.CSRF.TrustedOrigins), len(want))
+			len(bundle.CSRF.TrustedOrigins), len(wantTrusted))
 	}
 	for i, got := range bundle.CSRF.TrustedOrigins {
-		if got != want[i] {
-			t.Errorf("CSRF.TrustedOrigins[%d]: got %q, want %q", i, got, want[i])
+		if got != wantTrusted[i] {
+			t.Errorf("CSRF.TrustedOrigins[%d]: got %q, want %q", i, got, wantTrusted[i])
 		}
 	}
 
-	// Origin allowlist must also match — the two are threaded from the
-	// same resolution slice; a regression would surface as a divergence.
-	if len(bundle.Origin.AllowedOrigins) != len(want) {
+	if len(bundle.Origin.AllowedOrigins) != len(allowed) {
 		t.Fatalf("Origin.AllowedOrigins length: got %d, want %d",
-			len(bundle.Origin.AllowedOrigins), len(want))
+			len(bundle.Origin.AllowedOrigins), len(allowed))
 	}
 }
 
@@ -305,8 +306,8 @@ func TestBuildAuthBundle_EnvOverrideThreadsTrustedOrigins(t *testing.T) {
 	}
 
 	wantHosts := []string{
-		"https://env.example.com",
-		"https://env-staging.example.com",
+		"env.example.com",
+		"env-staging.example.com",
 	}
 	if len(bundle.CSRF.TrustedOrigins) != len(wantHosts) {
 		t.Fatalf("env-override CSRF.TrustedOrigins length: got %v, want %v",
@@ -315,6 +316,48 @@ func TestBuildAuthBundle_EnvOverrideThreadsTrustedOrigins(t *testing.T) {
 	for i, got := range bundle.CSRF.TrustedOrigins {
 		if got != wantHosts[i] {
 			t.Errorf("CSRF.TrustedOrigins[%d]: got %q, want %q", i, got, wantHosts[i])
+		}
+	}
+}
+
+func TestBuildAuthBundle_ExpandsLocalhostWildcardForCSRFTrustedOrigins(t *testing.T) {
+	t.Setenv("FLOWSTATE_AUTH_ENABLED", "")
+	t.Setenv("FLOWSTATE_AUTH_CSRF_KEY", "")
+	t.Setenv("FLOWSTATE_AUTH_ALLOWED_ORIGINS", "")
+
+	cfg := &config.AppConfig{
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			Mode:           identity.ModeDeploymentLogin,
+			Secret:         "operator-secret",
+			PrincipalID:    "operator-id",
+			CSRFKey:        strings.Repeat("a", 32),
+			SecureCookies:  false,
+			AllowedOrigins: []string{"localhost:*"},
+		},
+	}
+
+	bundle, _, err := buildAuthBundle(cfg)
+	if err != nil {
+		t.Fatalf("buildAuthBundle: %v", err)
+	}
+
+	wantHosts := []string{
+		"localhost:5173",
+		"localhost:5174",
+		"127.0.0.1:5173",
+		"127.0.0.1:5174",
+	}
+	for _, want := range wantHosts {
+		found := false
+		for _, got := range bundle.CSRF.TrustedOrigins {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("CSRF.TrustedOrigins missing %q in %v", want, bundle.CSRF.TrustedOrigins)
 		}
 	}
 }

--- a/internal/session/accumulator.go
+++ b/internal/session/accumulator.go
@@ -412,28 +412,13 @@ func AccumulateStream(
 			select {
 			case chunk, ok := <-rawCh:
 				if !ok {
-					flushThinking(appender, s)
-					flushContent(appender, s)
 					// Symmetric with the chunk.Done and ctx.Done() paths
 					// below: when a turn produced reasoning only and the
 					// upstream channel closes without ever emitting a
-					// terminal Done chunk, still synthesise the
-					// placeholder assistant Message so the persisted
-					// history holds the thinking blocks under an
-					// assistant turn (and not as a stranded Role:
-					// "thinking" with no enclosing assistant). The
-					// OpenAI-compat layer only emits Done when
-					// FinishReason != "" (see
-					// internal/provider/openaicompat/openaicompat.go:229-232),
-					// so a thinking-only turn from a reasoning provider
-					// (zai/glm-4.6, DeepSeek-R1) hits this branch in
-					// production whenever the engine's own Done
-					// injection is bypassed (direct accumulator callers,
-					// future regressions). The synthesis is gated on
-					// the same predicates as the Done path —
-					// content-only and thinking-then-tool-call turns are
-					// untouched.
-					synthesizePlaceholderAssistant(appender, s)
+					// terminal Done chunk, finalise the turn so the
+					// persisted history has a renderable assistant
+					// artefact instead of stranded thinking.
+					finalizeTurn(appender, s)
 					return
 				}
 				applyChunk(appender, s, chunk)
@@ -443,14 +428,11 @@ func AccumulateStream(
 				select {
 				case accumCh <- chunk:
 				case <-ctx.Done():
-					flushThinking(appender, s)
-					flushContent(appender, s)
+					finalizeTurn(appender, s)
 					return
 				}
 			case <-ctx.Done():
-				flushThinking(appender, s)
-				flushContent(appender, s)
-				synthesizePlaceholderAssistant(appender, s)
+				finalizeTurn(appender, s)
 				return
 			}
 		}
@@ -515,9 +497,7 @@ func applyChunk(appender MessageAppender, s *streamAccumState, chunk provider.St
 		// per-bubble usage badge) read them from the live stream.
 		return
 	case chunk.Done:
-		flushThinking(appender, s)
-		flushContent(appender, s)
-		synthesizePlaceholderAssistant(appender, s)
+		finalizeTurn(appender, s)
 	default:
 		if chunk.EventType != "" {
 			return
@@ -799,6 +779,104 @@ func flushContent(appender MessageAppender, s *streamAccumState) {
 	// no-op rather than emitting an empty-turn placeholder beside the
 	// just-flushed content.
 	s.turnPlaceholderEmitted = true
+}
+
+// finalizeTurn drains any pending stream buffers and persists the assistant
+// artefact for the current turn.
+func finalizeTurn(appender MessageAppender, s *streamAccumState) {
+	if promoteTerminalThinkingToContent(appender, s) {
+		return
+	}
+	flushThinking(appender, s)
+	flushContent(appender, s)
+	synthesizePlaceholderAssistant(appender, s)
+}
+
+// promoteTerminalThinkingToContent handles OpenAI-compatible providers that
+// occasionally put the final user-facing answer on the reasoning channel
+// (`reasoning_content`) instead of the assistant content channel.
+//
+// The promotion is deliberately conservative: only unsigned, terminal,
+// answer-shaped thinking from non-unified providers is converted. Ordinary
+// reasoning still lands in a thinking message plus the existing degraded
+// placeholder, preserving the debugging affordance and avoiding accidental
+// exposure of scratchpad text as an assistant answer.
+func promoteTerminalThinkingToContent(appender MessageAppender, s *streamAccumState) bool {
+	if s.contentBuf.Len() != 0 || s.thinkingBuf.Len() == 0 {
+		return false
+	}
+	if providerProducesUnifiedAssistant(s.lastProviderID) {
+		return false
+	}
+	if s.pendingThinkingSignature != "" {
+		return false
+	}
+	thinking := s.thinkingBuf.String()
+	if !looksLikeAssistantAnswer(thinking) {
+		return false
+	}
+	msg := Message{
+		Role:         "assistant",
+		Content:      strings.TrimSpace(thinking),
+		AgentID:      s.agentID,
+		ModelName:    s.lastModelID,
+		ProviderName: s.lastProviderID,
+		StopReason:   s.turnStopReason,
+	}
+	if len(s.thinkingBlocks) > 0 {
+		blocks := make([]provider.ThinkingBlock, len(s.thinkingBlocks))
+		copy(blocks, s.thinkingBlocks)
+		msg.ThinkingBlocks = blocks
+	}
+	appender.AppendMessage(s.sessionID, msg)
+	s.thinkingBuf.Reset()
+	s.pendingThinkingSignature = ""
+	s.thinkingBlocks = nil
+	s.turnStopReason = ""
+	s.turnPlaceholderEmitted = true
+	return true
+}
+
+func looksLikeAssistantAnswer(text string) bool {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return false
+	}
+	lower := strings.ToLower(t)
+	reasoningPrefixes := []string{
+		"i need to",
+		"i should",
+		"i'll ",
+		"let me",
+		"looking at",
+		"now i",
+		"the user",
+		"we need to",
+	}
+	for _, prefix := range reasoningPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return false
+		}
+	}
+	answerPrefixes := []string{
+		"#",
+		"- ",
+		"1. ",
+		"done",
+		"all set",
+		"below ",
+		"here ",
+		"here's ",
+		"your ",
+	}
+	for _, prefix := range answerPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return strings.Contains(t, "\n## ") ||
+		strings.Contains(t, "\n### ") ||
+		strings.Contains(t, "\n|")
 }
 
 // StopReasonThinkingOnly is the synthetic stop reason stamped on a

--- a/internal/session/accumulator_test.go
+++ b/internal/session/accumulator_test.go
@@ -1502,6 +1502,75 @@ var _ = Describe("AccumulateStream", func() {
 			Expect(assistantMsgs[0].ProviderName).To(Equal("zai"))
 		})
 
+		It("promotes answer-shaped terminal raw thinking from zai into assistant content", func() {
+			// Regression pin (May 2026): GLM via Z.ai can emit the final
+			// user-facing markdown answer on `reasoning_content` instead of
+			// `content`. If the accumulator blindly flushes that as Role:
+			// "thinking", the UI shows the real reply inside a THINKING
+			// block and then adds "Reply didn't come through" from the
+			// empty assistant placeholder. Answer-shaped terminal thinking
+			// from non-unified providers should render as the assistant
+			// reply instead.
+			rawCh := make(chan provider.StreamChunk, 3)
+			rawCh <- provider.StreamChunk{
+				Thinking:   "## Your Life Admin Action Plan\n\nStart Here\n\n1. Find the reference number.",
+				ProviderID: "zai",
+				ModelID:    "glm-4.6",
+			}
+			rawCh <- provider.StreamChunk{Done: true, ProviderID: "zai", ModelID: "glm-4.6"}
+			close(rawCh)
+
+			out := session.AccumulateStream(context.Background(), appender, "sess-1", "agent-1", rawCh)
+			drainChannel(out)
+
+			var thinkingMsgs []session.Message
+			var assistantMsgs []session.Message
+			for _, m := range appender.messages {
+				switch m.Role {
+				case "thinking":
+					thinkingMsgs = append(thinkingMsgs, m)
+				case "assistant":
+					assistantMsgs = append(assistantMsgs, m)
+				}
+			}
+			Expect(thinkingMsgs).To(BeEmpty(),
+				"the final user-facing answer must not be stranded in a visible THINKING block")
+			Expect(assistantMsgs).To(HaveLen(1),
+				"the answer-shaped terminal reasoning should become the assistant reply")
+			Expect(assistantMsgs[0].Content).To(ContainSubstring("Your Life Admin Action Plan"))
+			Expect(assistantMsgs[0].ThinkingBlocks).To(BeEmpty(),
+				"the promoted answer itself is not replayable model thinking")
+			Expect(assistantMsgs[0].StopReason).NotTo(Equal(session.StopReasonThinkingOnly),
+				"content-bearing promoted answers must not trigger the thinking-only UI affordance")
+			Expect(assistantMsgs[0].ProviderName).To(Equal("zai"))
+			Expect(assistantMsgs[0].ModelName).To(Equal("glm-4.6"))
+		})
+
+		It("promotes answer-shaped terminal raw thinking on close-without-Done", func() {
+			rawCh := make(chan provider.StreamChunk, 2)
+			rawCh <- provider.StreamChunk{
+				Thinking:   "Here is the concise action plan.\n\n- Send the payment-plan email.",
+				ProviderID: "zai",
+				ModelID:    "glm-4.6",
+			}
+			close(rawCh)
+
+			out := session.AccumulateStream(context.Background(), appender, "sess-1", "agent-1", rawCh)
+			drainChannel(out)
+
+			var assistantMsgs []session.Message
+			for _, m := range appender.messages {
+				if m.Role == "assistant" {
+					assistantMsgs = append(assistantMsgs, m)
+				}
+			}
+			Expect(assistantMsgs).To(HaveLen(1),
+				"the close-without-Done path should use the same terminal-answer promotion")
+			Expect(assistantMsgs[0].Content).To(ContainSubstring("concise action plan"))
+			Expect(assistantMsgs[0].StopReason).NotTo(Equal(session.StopReasonThinkingOnly))
+			Expect(assistantMsgs[0].ProviderName).To(Equal("zai"))
+		})
+
 		It("DOES synthesise an empty_turn placeholder when the turn produced no content AND no thinking AND no tools (Slice C — Streaming Coherence May 2026)", func() {
 			// Streaming Coherence Slice C — pre-slice this behaviour was
 			// "no placeholder; the in-flight bubble is left to the watchdog".

--- a/web/src/App.spec.ts
+++ b/web/src/App.spec.ts
@@ -3,6 +3,13 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import App from './App.vue'
 import { useChatStore } from '@/stores/chatStore'
+import { ApiError } from '@/lib/apiError'
+
+const routerReplaceMock = vi.hoisted(() => vi.fn())
+const routeState = vi.hoisted(() => ({
+  path: '/chat',
+  name: 'chat' as string | undefined,
+}))
 
 // App-level test surface — pins the loading-overlay contract that gates
 // first-paint of the application until bootstrap (health-check + the
@@ -36,8 +43,8 @@ vi.mock('@/api', async (importOriginal) => {
 // auto-resolution that the router plugin would normally provide.
 vi.mock('vue-router', () => ({
   RouterView: { name: 'RouterView', template: '<div data-testid="router-view-stub"></div>' },
-  useRouter: () => ({ push: vi.fn() }),
-  useRoute: () => ({ path: '/chat' }),
+  useRouter: () => ({ push: vi.fn(), replace: routerReplaceMock }),
+  useRoute: () => routeState,
 }))
 
 const mountOptions = {
@@ -63,6 +70,9 @@ vi.mock('@/components/common/ToastContainer.vue', () => ({
 describe('App loading overlay', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    routerReplaceMock.mockClear()
+    routeState.path = '/chat'
+    routeState.name = 'chat'
     // Default: a healthy backend so the health-check resolves quickly.
     vi.stubGlobal(
       'fetch',
@@ -129,6 +139,30 @@ describe('App loading overlay', () => {
 
     expect(wrapper.find('[data-testid="app-loading-overlay"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="router-view-stub"]').exists()).toBe(true)
+  })
+
+  it('redirects to /login when bootstrap rejects because the session is unauthorised', async () => {
+    const chatStore = useChatStore()
+    vi.spyOn(chatStore, 'bootstrap').mockRejectedValue(
+      new ApiError('Failed to fetch sessions: Unauthorized', 401, 'Unauthorized'),
+    )
+
+    mount(App, mountOptions)
+    await flushPromises()
+
+    expect(routerReplaceMock).toHaveBeenCalledWith('/login')
+  })
+
+  it('does not bootstrap chat history while the current route is /login', async () => {
+    routeState.path = '/login'
+    routeState.name = 'login'
+    const chatStore = useChatStore()
+    const bootstrapSpy = vi.spyOn(chatStore, 'bootstrap')
+
+    mount(App, mountOptions)
+    await flushPromises()
+
+    expect(bootstrapSpy).not.toHaveBeenCalled()
   })
 
   it('still dismisses the overlay when the health-check rejects', async () => {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import NavBar from '@/components/layout/NavBar.vue'
 import ToastContainer from '@/components/common/ToastContainer.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import { useChatStore } from '@/stores/chatStore'
+import { isUnauthorizedError } from '@/lib/apiError'
 
 // appReady: drives the loading-overlay gate. Stays false until both
 // async bootstrap promises (the /api/health probe and chatStore.bootstrap)
@@ -19,6 +21,8 @@ import { useChatStore } from '@/stores/chatStore'
 const appReady = ref(false)
 const apiOnline = ref(true)
 const chatStore = useChatStore()
+const router = useRouter()
+const route = useRoute()
 
 // UI Parity PR6 N10 (May 2026) — min-duration gate.
 //
@@ -32,6 +36,10 @@ const chatStore = useChatStore()
 // chrome (so the page underneath stays hidden during real slow boots).
 const overlayVisible = ref(false)
 const OVERLAY_MIN_DELAY_MS = 200
+
+function isLoginRoute(): boolean {
+  return route.name === 'login' || route.path === '/login'
+}
 
 onMounted(async () => {
   // Tear down the index.html splash so the Vue overlay can take over
@@ -60,7 +68,13 @@ onMounted(async () => {
       apiOnline.value = false
     }
   })()
-  await Promise.allSettled([healthPromise, chatStore.bootstrap()])
+  const bootstrapPromise = isLoginRoute() ? Promise.resolve() : chatStore.bootstrap()
+  const results = await Promise.allSettled([healthPromise, bootstrapPromise])
+  const bootstrapResult = results[1]
+  if (bootstrapResult.status === 'rejected' && isUnauthorizedError(bootstrapResult.reason)) {
+    chatStore.resetBootstrap()
+    await router.replace('/login')
+  }
 
   clearTimeout(overlayTimer)
   appReady.value = true

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -10,8 +10,11 @@ import type {
   Swarm,
 } from '@/types'
 import { parseError } from '@/lib/parseError'
-import { isAllowedApiHost } from '@/lib/apiHostAllowlist'
+import { joinBaseURL } from '@/lib/apiBase'
+import { apiErrorFromResponse } from '@/lib/apiError'
 import { withCsrfHeader } from '@/lib/csrf'
+
+export { joinBaseURL } from '@/lib/apiBase'
 
 // PR3 / C8 — auth coordinated change. Every fetch() in this module
 // adds `credentials: 'include'` so the browser sends the
@@ -30,50 +33,6 @@ import { withCsrfHeader } from '@/lib/csrf'
 // CREDENTIALS_INCLUDE is the shared RequestCredentials literal so the
 // constant is referenced consistently across every fetch site.
 const CREDENTIALS_INCLUDE: RequestCredentials = 'include'
-
-const BASE = '/api'
-const API_HOST_STORAGE_KEY = 'flowstate-api-host'
-
-/**
- * getBaseURL returns the API base URL, validated against the host
- * allowlist. A localStorage value that fails the allowlist (e.g. injected
- * by an XSS vector or a malicious bookmarklet) is removed and the safe
- * BASE default is returned. See apiHostAllowlist.ts for the policy and
- * threat model.
- */
-function getBaseURL(): string {
-  let stored: string | null = null
-  try {
-    stored = localStorage.getItem(API_HOST_STORAGE_KEY)
-  } catch {
-    // localStorage unavailable (private mode, SSR) — fall through to default.
-    return BASE
-  }
-  if (!stored) return BASE
-  if (!isAllowedApiHost(stored)) {
-    // Hostile or malformed override — clear it and warn (validateApiHost
-    // would also warn, but we want to log AND remove). The next page load
-    // sees the BASE default; in-flight requests in the same tick still
-    // see BASE because we returned it below.
-    try {
-      localStorage.removeItem(API_HOST_STORAGE_KEY)
-    } catch {
-      // best effort — fall through
-    }
-    // eslint-disable-next-line no-console
-    console.warn(
-      '[flowstate] cleared API host override that failed allowlist policy:',
-      stored,
-    )
-    return BASE
-  }
-  return stored
-}
-
-export function joinBaseURL(path: string): string {
-  const base = getBaseURL().replace(/\/$/, '')
-  return `${base}${path}`
-}
 
 export async function fetchAgents(): Promise<Agent[]> {
   const res = await fetch(joinBaseURL('/agents'), { credentials: CREDENTIALS_INCLUDE })
@@ -176,7 +135,7 @@ export async function fetchSwarmEvents(): Promise<unknown[]> {
 export async function fetchSessions(): Promise<SessionSummary[]> {
   const res = await fetch(joinBaseURL('/v1/sessions'), { credentials: CREDENTIALS_INCLUDE })
   if (!res.ok) {
-    throw new Error(`Failed to fetch sessions: ${res.statusText}`)
+    throw apiErrorFromResponse('Failed to fetch sessions', res)
   }
   return res.json()
 }

--- a/web/src/lib/apiBase.ts
+++ b/web/src/lib/apiBase.ts
@@ -1,0 +1,40 @@
+import { isAllowedApiHost } from '@/lib/apiHostAllowlist'
+
+const BASE = '/api'
+const API_HOST_STORAGE_KEY = 'flowstate-api-host'
+
+/**
+ * getBaseURL returns the API base URL, validated against the host
+ * allowlist. A localStorage value that fails the allowlist is removed
+ * and the safe BASE default is returned.
+ */
+function getBaseURL(): string {
+  let stored: string | null = null
+  try {
+    stored = localStorage.getItem(API_HOST_STORAGE_KEY)
+  } catch {
+    return BASE
+  }
+  if (!stored) return BASE
+  if (!isAllowedApiHost(stored)) {
+    try {
+      localStorage.removeItem(API_HOST_STORAGE_KEY)
+    } catch {
+      return BASE
+    }
+    console.warn(
+      '[flowstate] cleared API host override that failed allowlist policy:',
+      stored,
+    )
+    return BASE
+  }
+  return stored
+}
+
+/**
+ * joinBaseURL prefixes an API path with the configured API base.
+ */
+export function joinBaseURL(path: string): string {
+  const base = getBaseURL().replace(/\/$/, '')
+  return `${base}${path}`
+}

--- a/web/src/lib/apiError.spec.ts
+++ b/web/src/lib/apiError.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { ApiError, apiErrorFromResponse, isUnauthorizedError } from './apiError'
+
+describe('apiErrorFromResponse', () => {
+  it('preserves the existing message shape while attaching the HTTP status', () => {
+    const response = new Response('', { status: 401, statusText: 'Unauthorized' })
+    const error = apiErrorFromResponse('Failed to fetch sessions', response)
+
+    expect(error.message).toBe('Failed to fetch sessions: Unauthorized')
+    expect(error.status).toBe(401)
+    expect(error.statusText).toBe('Unauthorized')
+  })
+})
+
+describe('isUnauthorizedError', () => {
+  it('matches ApiError instances with HTTP 401 status', () => {
+    expect(isUnauthorizedError(new ApiError('anything', 401, 'Unauthorized'))).toBe(true)
+  })
+
+  it('matches legacy plain Error messages that mention Unauthorized', () => {
+    expect(isUnauthorizedError(new Error('Failed to fetch sessions: Unauthorized'))).toBe(true)
+  })
+
+  it('does not match unrelated network errors', () => {
+    expect(isUnauthorizedError(new Error('network down'))).toBe(false)
+  })
+})

--- a/web/src/lib/apiError.ts
+++ b/web/src/lib/apiError.ts
@@ -1,0 +1,38 @@
+/**
+ * ApiError carries the HTTP status alongside the user-facing API error
+ * message.
+ */
+export class ApiError extends Error {
+  status: number
+  statusText: string
+
+  constructor(message: string, status: number, statusText: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.statusText = statusText
+  }
+}
+
+/**
+ * apiErrorFromResponse builds a status-aware API error while preserving
+ * the existing `<context>: <statusText>` message shape.
+ */
+export function apiErrorFromResponse(context: string, response: Response): ApiError {
+  const statusText = response.statusText || `HTTP ${response.status}`
+  return new ApiError(`${context}: ${statusText}`, response.status, response.statusText)
+}
+
+/**
+ * isUnauthorizedError reports whether an error represents an auth/session
+ * failure that should send the user to the login view.
+ */
+export function isUnauthorizedError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 401
+  }
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return /\b(?:401|Unauthorized|unauthenticated)\b/i.test(error.message)
+}

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -998,6 +998,10 @@ export const useChatStore = defineStore('chat', {
       return this.bootstrapPromise
     },
 
+    resetBootstrap(): void {
+      this.bootstrapPromise = null
+    },
+
     async restoreStateFromBackend(): Promise<void> {
       await this.loadAgents()
       await this.loadSwarms()

--- a/web/src/stores/csrfStore.test.ts
+++ b/web/src/stores/csrfStore.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useCsrfStore } from './csrfStore'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('csrfStore', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('stores a token supplied by the login response', () => {
+    const store = useCsrfStore()
+    store.setToken('post-login-token')
+
+    expect(store.tokenValue).toBe('post-login-token')
+  })
+
+  it('fetches /api/auth/csrf with credentials on cache miss', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { csrf_token: 'fresh-token' }))
+
+    const store = useCsrfStore()
+    const token = await store.ensureToken()
+
+    expect(token).toBe('fresh-token')
+    expect(store.tokenValue).toBe('fresh-token')
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/csrf', {
+      method: 'GET',
+      credentials: 'include',
+    })
+  })
+
+  it('uses the configured API host for the prefetch endpoint', async () => {
+    localStorage.setItem('flowstate-api-host', 'http://localhost:8080/api')
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { csrf_token: 'fresh-token' }))
+
+    const store = useCsrfStore()
+    await store.ensureToken()
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8080/api/auth/csrf', {
+      method: 'GET',
+      credentials: 'include',
+    })
+  })
+
+  it('returns the cached token without fetching', async () => {
+    const store = useCsrfStore()
+    store.setToken('cached-token')
+
+    await expect(store.ensureToken()).resolves.toBe('cached-token')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('coalesces concurrent cache misses into one fetch', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { csrf_token: 'shared-token' }))
+
+    const store = useCsrfStore()
+    const [first, second] = await Promise.all([
+      store.ensureToken(),
+      store.ensureToken(),
+    ])
+
+    expect(first).toBe('shared-token')
+    expect(second).toBe('shared-token')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the in-flight request after a failed prefetch so a retry can succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(500, { error: 'boom' }))
+      .mockResolvedValueOnce(jsonResponse(200, { csrf_token: 'retry-token' }))
+
+    const store = useCsrfStore()
+    await expect(store.ensureToken()).rejects.toThrow(/csrf/i)
+    await expect(store.ensureToken()).resolves.toBe('retry-token')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web/src/stores/csrfStore.ts
+++ b/web/src/stores/csrfStore.ts
@@ -1,0 +1,60 @@
+import { defineStore } from 'pinia'
+import { joinBaseURL } from '@/lib/apiBase'
+
+interface CSRFPrefetchResponse {
+  csrf_token?: string
+}
+
+interface CSRFStoreState {
+  tokenValue: string
+  fetchInFlight: Promise<string> | null
+}
+
+/**
+ * useCsrfStore caches the masked CSRF token used for unsafe API requests.
+ */
+export const useCsrfStore = defineStore('csrf', {
+  state: (): CSRFStoreState => ({
+    tokenValue: '',
+    fetchInFlight: null,
+  }),
+
+  actions: {
+    setToken(token: string): void {
+      this.tokenValue = token
+    },
+
+    async ensureToken(): Promise<string> {
+      if (this.tokenValue) {
+        return this.tokenValue
+      }
+      if (this.fetchInFlight) {
+        return this.fetchInFlight
+      }
+
+      const request = fetch(joinBaseURL('/auth/csrf'), {
+        method: 'GET',
+        credentials: 'include',
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`CSRF prefetch failed: ${response.status}`)
+          }
+          const body = (await response.json()) as CSRFPrefetchResponse
+          if (typeof body.csrf_token !== 'string' || body.csrf_token === '') {
+            throw new Error('CSRF prefetch response did not include csrf_token')
+          }
+          this.setToken(body.csrf_token)
+          return body.csrf_token
+        })
+        .finally(() => {
+          if (this.fetchInFlight === request) {
+            this.fetchInFlight = null
+          }
+        })
+
+      this.fetchInFlight = request
+      return request
+    },
+  },
+})

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         target: 'http://localhost:8080',
-        changeOrigin: true,
+        changeOrigin: false,
       },
     },
   },


### PR DESCRIPTION
- Bind login responses to the gorilla/csrf token so the returned `csrf_token` works for subsequent protected unsafe requests.
- Normalise CSRF trusted origins, including local Vite/dev host expansions, so configured auth origins and CSRF origin checks stay aligned.
- Add frontend API base/error helpers plus a Pinia CSRF token cache for masked-token reuse and prefetching.
- Redirect unauthorised app bootstrap failures to `/login` and skip chat bootstrap while already on the login route.
- Promote answer-shaped terminal reasoning from non-unified providers into assistant content so chat replies do not render as thinking plus an empty fallback.